### PR TITLE
Make GitHub Action actually work

### DIFF
--- a/docs/CI_CD_Integrations.md
+++ b/docs/CI_CD_Integrations.md
@@ -35,7 +35,7 @@ jobs:
         esac
 
     - name: Setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 'stable'
 

--- a/docs/CI_CD_Integrations.md
+++ b/docs/CI_CD_Integrations.md
@@ -12,20 +12,38 @@ on:
 
 jobs:
   run-terraform-check:
+    permissions:
+      pull-requests: write
+
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Go
+    - name: Outputs
+      id: vars
+      run: |
+        echo "terramaid_version=$(curl -s https://api.github.com/repos/RoseSecurity/Terramaid/releases/latest | grep tag_name | cut -d '"' -f 4)" >> $GITHUB_OUTPUT
+        case "${{ runner.arch }}" in
+          "X64" )
+            echo "arch=x86_64" >> $GITHUB_OUTPUT
+            ;;
+          "ARM64" )
+            echo "arch=arm64" >> $GITHUB_OUTPUT
+            ;;
+        esac
+
+    - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: 'stable'
 
-    - name: Download Go binary
+    - name: Setup Terramaid
       run: |
-        curl -L -o /usr/local/bin/terramaid https://github.com/RoseSecurity/Terramaid/releases/download/v0.1.0/Terramaid_0.1.0_linux_amd64
+        curl -L -o /tmp/terramaid.tar.gz "https://github.com/RoseSecurity/Terramaid/releases/download/${{ steps.vars.outputs.terramaid_version }}/Terramaid_Linux_${{ steps.vars.outputs.arch }}.tar.gz"
+        tar -xzvf /tmp/terramaid.tar.gz -C /tmp
+        mv -v /tmp/Terramaid /usr/local/bin/terramaid
         chmod +x /usr/local/bin/terramaid
 
     - name: Init
@@ -34,11 +52,12 @@ jobs:
     - name: Terramaid
       id: terramaid
       run: |
-        ./usr/local/bin/terramaid
+        /usr/local/bin/terramaid
 
     - name: Upload comment to PR
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const fs = require('fs');
           const terramaid = fs.readFileSync('Terramaid.md', 'utf8');
@@ -47,7 +66,7 @@ jobs:
             repo: context.repo.repo,
             issue_number: context.issue.number,
             body: `## Terraform Plan\n\n${terramaid}`
-          });
+          })
 ```
 
 ## GitLab CI/CD Pipelines


### PR DESCRIPTION
* Needs permission to write to PR
* Permission also includes GITHUB_TOKEN
* Correct Terramaid binary
* Just use the latest version of Go and Terramaid
* Actions versions still running on Node.js 16
* Don't get stuck on amd64 only when there's an arm64 binary available (very useful when using a cheaper custom runner using ARM)