### PR TITLE
Add Homebrew Auto Bump Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,3 +59,17 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: rosesecurity/terramaid:latest
+
+  homebrew:
+    name: "Bump Homebrew Formula"
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
+          formula-name: terramaid
+          formula-path: Formula/t/terramaid.rb
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+


### PR DESCRIPTION
## What and Why

- Create PRs to automatically bump the Formula version of Terramaid for Homebrew

## References

- [Workflow Docs](https://github.com/mislav/bump-homebrew-formula-action)