### PR TITLE
feat(functionality): add -v, --verbose flag that prints output

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Flags:
   -b, --tf-binary string       Path to Terraform binary (env: TERRAMAID_TF_BINARY)
   -p, --tf-plan string         Path to Terraform plan file (env: TERRAMAID_TF_PLAN)
   -w, --working-dir string     Working directory for Terraform (env: TERRAMAID_WORKING_DIR) (default ".")
+  -v, --verbose                Verbose output to terminal (boolean) (env: TERRAMAID_VERBOSE) (default false)
 
 Use "terramaid [command] --help" for more information about a command.
 ```

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Flags:
   -b, --tf-binary string       Path to Terraform binary (env: TERRAMAID_TF_BINARY)
   -p, --tf-plan string         Path to Terraform plan file (env: TERRAMAID_TF_PLAN)
   -w, --working-dir string     Working directory for Terraform (env: TERRAMAID_WORKING_DIR) (default ".")
-  -v, --verbose                Verbose output to terminal (boolean) (env: TERRAMAID_VERBOSE) (default false)
+  -v, --verbose bool           Verbose output to terminal (env: TERRAMAID_VERBOSE) (default false)
 
 Use "terramaid [command] --help" for more information about a command.
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,9 @@ func init() {
 	rootCmd.AddCommand(docsCmd)
 	rootCmd.AddCommand(versionCmd)
 
+	// Add global flags
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+
 	// Disable auto-generated string from documentation so that documentation is cleanly built and updated
 	rootCmd.DisableAutoGenTag = true
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,6 +22,7 @@ type options struct {
 	Direction    string `env:"DIRECTION" envDefault:"TD"`
 	SubgraphName string `env:"SUBGRAPH_NAME" envDefault:"Terraform"`
 	ChartType    string `env:"CHART_TYPE" envDefault:"flowchart"`
+	Verbose      bool   `env:"VERBOSE" envDefault:"false"`
 }
 
 var opts options // Global variable for flags and env variables
@@ -38,6 +39,17 @@ var runCmd = &cobra.Command{
 }
 
 func generateDiagrams(opts *options) error {
+	if opts.Verbose {
+		utils.LogVerbose("Starting Terramaid with the following options:")
+		utils.LogVerbose("- Working Directory: %s", opts.WorkingDir)
+		utils.LogVerbose("- Terraform Plan: %s", opts.TFPlan)
+		utils.LogVerbose("- Terraform Binary: %s", opts.TFBinary)
+		utils.LogVerbose("- Output File: %s", opts.Output)
+		utils.LogVerbose("- Direction: %s", opts.Direction)
+		utils.LogVerbose("- Subgraph Name: %s", opts.SubgraphName)
+		utils.LogVerbose("- Chart Type: %s", opts.ChartType)
+	}
+
 	if opts.WorkingDir != "" {
 		exists, err := utils.TerraformFilesExist(opts.WorkingDir)
 		if err != nil {
@@ -45,6 +57,9 @@ func generateDiagrams(opts *options) error {
 		}
 		if !exists {
 			return fmt.Errorf("Terraform files do not exist in directory \"%s\"", opts.WorkingDir)
+		}
+		if opts.Verbose {
+			utils.LogVerbose("Confirmed Terraform files exist in %s", opts.WorkingDir)
 		}
 	}
 
@@ -60,26 +75,38 @@ func generateDiagrams(opts *options) error {
 			return fmt.Errorf("error finding Terraform binary: %w", err)
 		}
 		opts.TFBinary = tfBinary
+		if opts.Verbose {
+			utils.LogVerbose("Terraform binary found at: %s", opts.TFBinary)
+		}
 	}
 
 	// Spinner initialization and graph parsing
 	sp := utils.NewSpinner("Generating Terramaid Diagrams")
 	sp.Start()
 
-	graph, err := internal.ParseTerraform(opts.WorkingDir, opts.TFBinary, opts.TFPlan)
+	if opts.Verbose {
+		utils.LogVerbose("Initializing Terraform and building graph...")
+	}
+	graph, err := internal.ParseTerraform(opts.WorkingDir, opts.TFBinary, opts.TFPlan, opts.Verbose)
 	if err != nil {
 		sp.Stop()
 		return fmt.Errorf("error parsing Terraform: %w", err)
 	}
 
 	// Generate the Mermaid diagram
-	mermaidDiagram, err := internal.GenerateMermaidFlowchart(graph, opts.Direction, opts.SubgraphName)
+	if opts.Verbose {
+		utils.LogVerbose("Generating Mermaid flowchart...")
+	}
+	mermaidDiagram, err := internal.GenerateMermaidFlowchart(graph, opts.Direction, opts.SubgraphName, opts.Verbose)
 	if err != nil {
 		sp.Stop()
 		return fmt.Errorf("error generating Mermaid diagram: %w", err)
 	}
 
 	// Write the Mermaid diagram to the specified output file
+	if opts.Verbose {
+		utils.LogVerbose("Writing Mermaid diagram to %s", opts.Output)
+	}
 	if err := os.WriteFile(opts.Output, []byte(mermaidDiagram), 0o644); err != nil {
 		sp.Stop()
 		return fmt.Errorf("error writing to file: %w", err)
@@ -105,6 +132,7 @@ func init() {
 	runCmd.Flags().StringVarP(&opts.TFPlan, "tf-plan", "p", opts.TFPlan, "Path to Terraform plan file (env: TERRAMAID_TF_PLAN)")
 	runCmd.Flags().StringVarP(&opts.TFBinary, "tf-binary", "b", opts.TFBinary, "Path to Terraform binary (env: TERRAMAID_TF_BINARY)")
 	runCmd.Flags().StringVarP(&opts.WorkingDir, "working-dir", "w", opts.WorkingDir, "Working directory for Terraform (env: TERRAMAID_WORKING_DIR)")
+	runCmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Enable verbose output (env: TERRAMAID_VERBOSE)")
 
 	// Disable auto-generated string from documentation so that documentation is cleanly built and updated
 	runCmd.DisableAutoGenTag = true

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -1,47 +1,139 @@
 // Copyright (c) RoseSecurity
 // SPDX-License-Identifier: Apache-2.0
 
-package utils
+package cmd
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 
-	"github.com/fatih/color"
+	"github.com/RoseSecurity/terramaid/internal"
+	"github.com/RoseSecurity/terramaid/pkg/utils"
+	"github.com/caarlos0/env/v11"
+	"github.com/spf13/cobra"
 )
 
-const (
-	LogLevelTrace   = "Trace"
-	LogLevelDebug   = "Debug"
-	LogLevelInfo    = "Info"
-	LogLevelWarning = "Warning"
-)
-
-// LogErrorAndExit logs errors to std.Error and exits with an error code
-func LogErrorAndExit(err error) {
-	if err != nil {
-		LogError(err)
-
-		// Find the executed command's exit code from the error
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			exitCode := exitError.ExitCode()
-			os.Exit(exitCode)
-		}
-	}
+type options struct {
+	WorkingDir   string `env:"WORKING_DIR" envDefault:"."`
+	TFPlan       string `env:"TF_PLAN"`
+	TFBinary     string `env:"TF_BINARY"`
+	Output       string `env:"OUTPUT" envDefault:"Terramaid.md"`
+	Direction    string `env:"DIRECTION" envDefault:"TD"`
+	SubgraphName string `env:"SUBGRAPH_NAME" envDefault:"Terraform"`
+	ChartType    string `env:"CHART_TYPE" envDefault:"flowchart"`
+	Verbose      bool   `env:"VERBOSE" envDefault:"false"`
 }
 
-// LogError logs errors to std.Error
-func LogError(err error) {
-	if err != nil {
-		c := color.New(color.FgRed)
-		_, err2 := c.Fprintln(color.Error, err.Error()+"\n")
-		if err2 != nil {
-			color.Red("Error logging the error:")
-			color.Red("%s\n", err2)
-			color.Red("Original error:")
-			color.Red("%s\n", err)
+var opts options // Global variable for flags and env variables
+
+var runCmd = &cobra.Command{
+	Use:           "run",
+	Short:         "Generate Mermaid diagrams from Terraform configurations",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// The opts variable is automatically populated with flags here
+		return generateDiagrams(&opts)
+	},
+}
+
+func generateDiagrams(opts *options) error {
+	if opts.Verbose {
+		utils.LogVerbose("Starting Terramaid with the following options:")
+		utils.LogVerbose("- Working Directory: %s", opts.WorkingDir)
+		utils.LogVerbose("- Terraform Plan: %s", opts.TFPlan)
+		utils.LogVerbose("- Terraform Binary: %s", opts.TFBinary)
+		utils.LogVerbose("- Output File: %s", opts.Output)
+		utils.LogVerbose("- Direction: %s", opts.Direction)
+		utils.LogVerbose("- Subgraph Name: %s", opts.SubgraphName)
+		utils.LogVerbose("- Chart Type: %s", opts.ChartType)
+	}
+
+	if opts.WorkingDir != "" {
+		exists, err := utils.TerraformFilesExist(opts.WorkingDir)
+		if err != nil {
+			return fmt.Errorf("error checking Terraform files in directory \"%s\": %v", opts.WorkingDir, err)
+		}
+		if !exists {
+			return fmt.Errorf("Terraform files do not exist in directory \"%s\"", opts.WorkingDir)
+		}
+		if opts.Verbose {
+			utils.LogVerbose("Confirmed Terraform files exist in %s", opts.WorkingDir)
 		}
 	}
+
+	// Validate directories and files
+	if opts.WorkingDir != "" && !utils.DirExists(opts.WorkingDir) {
+		return fmt.Errorf("terraform directory \"%s\" does not exist", opts.WorkingDir)
+	}
+
+	// Check for Terraform binary
+	if opts.TFBinary == "" {
+		tfBinary, err := exec.LookPath("terraform")
+		if err != nil {
+			return fmt.Errorf("error finding Terraform binary: %w", err)
+		}
+		opts.TFBinary = tfBinary
+		if opts.Verbose {
+			utils.LogVerbose("Terraform binary found at: %s", opts.TFBinary)
+		}
+	}
+
+	// Spinner initialization and graph parsing
+	sp := utils.NewSpinner("Generating Terramaid Diagrams")
+	sp.Start()
+
+	if opts.Verbose {
+		utils.LogVerbose("Initializing Terraform and building graph...")
+	}
+	graph, err := internal.ParseTerraform(opts.WorkingDir, opts.TFBinary, opts.TFPlan, opts.Verbose)
+	if err != nil {
+		sp.Stop()
+		return fmt.Errorf("error parsing Terraform: %w", err)
+	}
+
+	// Generate the Mermaid diagram
+	if opts.Verbose {
+		utils.LogVerbose("Generating Mermaid flowchart...")
+	}
+	mermaidDiagram, err := internal.GenerateMermaidFlowchart(graph, opts.Direction, opts.SubgraphName, opts.Verbose)
+	if err != nil {
+		sp.Stop()
+		return fmt.Errorf("error generating Mermaid diagram: %w", err)
+	}
+
+	// Write the Mermaid diagram to the specified output file
+	if opts.Verbose {
+		utils.LogVerbose("Writing Mermaid diagram to %s", opts.Output)
+	}
+	if err := os.WriteFile(opts.Output, []byte(mermaidDiagram), 0o644); err != nil {
+		sp.Stop()
+		return fmt.Errorf("error writing to file: %w", err)
+	}
+
+	sp.Stop()
+	fmt.Printf("Mermaid diagram successfully written to %s\n", opts.Output)
+
+	return nil
+}
+
+func init() {
+	// Parse environment variables first, then bind flags to the opts struct
+	if err := env.ParseWithOptions(&opts, env.Options{Prefix: "TERRAMAID_"}); err != nil {
+		fmt.Printf("Error parsing environment variables: %s\n", err.Error())
+	}
+
+	// Bind flags to the opts struct
+	runCmd.Flags().StringVarP(&opts.Output, "output", "o", opts.Output, "Output file for Mermaid diagram (env: TERRAMAID_OUTPUT)")
+	runCmd.Flags().StringVarP(&opts.Direction, "direction", "r", opts.Direction, "Specify the direction of the diagram (env: TERRAMAID_DIRECTION)")
+	runCmd.Flags().StringVarP(&opts.SubgraphName, "subgraph-name", "s", opts.SubgraphName, "Specify the subgraph name of the diagram (env: TERRAMAID_SUBGRAPH_NAME)")
+	runCmd.Flags().StringVarP(&opts.ChartType, "chart-type", "c", opts.ChartType, "Specify the type of Mermaid chart to generate (env: TERRAMAID_CHART_TYPE)")
+	runCmd.Flags().StringVarP(&opts.TFPlan, "tf-plan", "p", opts.TFPlan, "Path to Terraform plan file (env: TERRAMAID_TF_PLAN)")
+	runCmd.Flags().StringVarP(&opts.TFBinary, "tf-binary", "b", opts.TFBinary, "Path to Terraform binary (env: TERRAMAID_TF_BINARY)")
+	runCmd.Flags().StringVarP(&opts.WorkingDir, "working-dir", "w", opts.WorkingDir, "Working directory for Terraform (env: TERRAMAID_WORKING_DIR)")
+	runCmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Enable verbose output (env: TERRAMAID_VERBOSE)")
+
+	// Disable auto-generated string from documentation so that documentation is cleanly built and updated
+	runCmd.DisableAutoGenTag = true
 }

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -1,139 +1,55 @@
 // Copyright (c) RoseSecurity
 // SPDX-License-Identifier: Apache-2.0
 
-package cmd
+package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 
-	"github.com/RoseSecurity/terramaid/internal"
-	"github.com/RoseSecurity/terramaid/pkg/utils"
-	"github.com/caarlos0/env/v11"
-	"github.com/spf13/cobra"
+	"github.com/fatih/color"
 )
 
-type options struct {
-	WorkingDir   string `env:"WORKING_DIR" envDefault:"."`
-	TFPlan       string `env:"TF_PLAN"`
-	TFBinary     string `env:"TF_BINARY"`
-	Output       string `env:"OUTPUT" envDefault:"Terramaid.md"`
-	Direction    string `env:"DIRECTION" envDefault:"TD"`
-	SubgraphName string `env:"SUBGRAPH_NAME" envDefault:"Terraform"`
-	ChartType    string `env:"CHART_TYPE" envDefault:"flowchart"`
-	Verbose      bool   `env:"VERBOSE" envDefault:"false"`
-}
+const (
+	LogLevelTrace   = "Trace"
+	LogLevelDebug   = "Debug"
+	LogLevelInfo    = "Info"
+	LogLevelWarning = "Warning"
+)
 
-var opts options // Global variable for flags and env variables
-
-var runCmd = &cobra.Command{
-	Use:           "run",
-	Short:         "Generate Mermaid diagrams from Terraform configurations",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// The opts variable is automatically populated with flags here
-		return generateDiagrams(&opts)
-	},
-}
-
-func generateDiagrams(opts *options) error {
-	if opts.Verbose {
-		utils.LogVerbose("Starting Terramaid with the following options:")
-		utils.LogVerbose("- Working Directory: %s", opts.WorkingDir)
-		utils.LogVerbose("- Terraform Plan: %s", opts.TFPlan)
-		utils.LogVerbose("- Terraform Binary: %s", opts.TFBinary)
-		utils.LogVerbose("- Output File: %s", opts.Output)
-		utils.LogVerbose("- Direction: %s", opts.Direction)
-		utils.LogVerbose("- Subgraph Name: %s", opts.SubgraphName)
-		utils.LogVerbose("- Chart Type: %s", opts.ChartType)
-	}
-
-	if opts.WorkingDir != "" {
-		exists, err := utils.TerraformFilesExist(opts.WorkingDir)
-		if err != nil {
-			return fmt.Errorf("error checking Terraform files in directory \"%s\": %v", opts.WorkingDir, err)
-		}
-		if !exists {
-			return fmt.Errorf("Terraform files do not exist in directory \"%s\"", opts.WorkingDir)
-		}
-		if opts.Verbose {
-			utils.LogVerbose("Confirmed Terraform files exist in %s", opts.WorkingDir)
-		}
-	}
-
-	// Validate directories and files
-	if opts.WorkingDir != "" && !utils.DirExists(opts.WorkingDir) {
-		return fmt.Errorf("terraform directory \"%s\" does not exist", opts.WorkingDir)
-	}
-
-	// Check for Terraform binary
-	if opts.TFBinary == "" {
-		tfBinary, err := exec.LookPath("terraform")
-		if err != nil {
-			return fmt.Errorf("error finding Terraform binary: %w", err)
-		}
-		opts.TFBinary = tfBinary
-		if opts.Verbose {
-			utils.LogVerbose("Terraform binary found at: %s", opts.TFBinary)
-		}
-	}
-
-	// Spinner initialization and graph parsing
-	sp := utils.NewSpinner("Generating Terramaid Diagrams")
-	sp.Start()
-
-	if opts.Verbose {
-		utils.LogVerbose("Initializing Terraform and building graph...")
-	}
-	graph, err := internal.ParseTerraform(opts.WorkingDir, opts.TFBinary, opts.TFPlan, opts.Verbose)
+// LogErrorAndExit logs errors to std.Error and exits with an error code
+func LogErrorAndExit(err error) {
 	if err != nil {
-		sp.Stop()
-		return fmt.Errorf("error parsing Terraform: %w", err)
-	}
+		LogError(err)
 
-	// Generate the Mermaid diagram
-	if opts.Verbose {
-		utils.LogVerbose("Generating Mermaid flowchart...")
+		// Find the executed command's exit code from the error
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			exitCode := exitError.ExitCode()
+			os.Exit(exitCode)
+		}
 	}
-	mermaidDiagram, err := internal.GenerateMermaidFlowchart(graph, opts.Direction, opts.SubgraphName, opts.Verbose)
-	if err != nil {
-		sp.Stop()
-		return fmt.Errorf("error generating Mermaid diagram: %w", err)
-	}
-
-	// Write the Mermaid diagram to the specified output file
-	if opts.Verbose {
-		utils.LogVerbose("Writing Mermaid diagram to %s", opts.Output)
-	}
-	if err := os.WriteFile(opts.Output, []byte(mermaidDiagram), 0o644); err != nil {
-		sp.Stop()
-		return fmt.Errorf("error writing to file: %w", err)
-	}
-
-	sp.Stop()
-	fmt.Printf("Mermaid diagram successfully written to %s\n", opts.Output)
-
-	return nil
 }
 
-func init() {
-	// Parse environment variables first, then bind flags to the opts struct
-	if err := env.ParseWithOptions(&opts, env.Options{Prefix: "TERRAMAID_"}); err != nil {
-		fmt.Printf("Error parsing environment variables: %s\n", err.Error())
+// LogError logs errors to std.Error
+func LogError(err error) {
+	if err != nil {
+		c := color.New(color.FgRed)
+		_, err2 := c.Fprintln(color.Error, err.Error()+"\n")
+		if err2 != nil {
+			color.Red("Error logging the error:")
+			color.Red("%s\n", err2)
+			color.Red("Original error:")
+			color.Red("%s\n", err)
+		}
 	}
+}
 
-	// Bind flags to the opts struct
-	runCmd.Flags().StringVarP(&opts.Output, "output", "o", opts.Output, "Output file for Mermaid diagram (env: TERRAMAID_OUTPUT)")
-	runCmd.Flags().StringVarP(&opts.Direction, "direction", "r", opts.Direction, "Specify the direction of the diagram (env: TERRAMAID_DIRECTION)")
-	runCmd.Flags().StringVarP(&opts.SubgraphName, "subgraph-name", "s", opts.SubgraphName, "Specify the subgraph name of the diagram (env: TERRAMAID_SUBGRAPH_NAME)")
-	runCmd.Flags().StringVarP(&opts.ChartType, "chart-type", "c", opts.ChartType, "Specify the type of Mermaid chart to generate (env: TERRAMAID_CHART_TYPE)")
-	runCmd.Flags().StringVarP(&opts.TFPlan, "tf-plan", "p", opts.TFPlan, "Path to Terraform plan file (env: TERRAMAID_TF_PLAN)")
-	runCmd.Flags().StringVarP(&opts.TFBinary, "tf-binary", "b", opts.TFBinary, "Path to Terraform binary (env: TERRAMAID_TF_BINARY)")
-	runCmd.Flags().StringVarP(&opts.WorkingDir, "working-dir", "w", opts.WorkingDir, "Working directory for Terraform (env: TERRAMAID_WORKING_DIR)")
-	runCmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Enable verbose output (env: TERRAMAID_VERBOSE)")
-
-	// Disable auto-generated string from documentation so that documentation is cleanly built and updated
-	runCmd.DisableAutoGenTag = true
+// LogVerbose logs messages in verbose mode
+func LogVerbose(format string, a ...interface{}) {
+	c := color.New(color.FgBlue)
+	message := fmt.Sprintf(format, a...)
+	c.Fprintf(color.Output, "[VERBOSE] %s\n", message)
 }


### PR DESCRIPTION
## Why

Adds a verbose output to terramaid runs for: 
Troubleshooting issues with Terraform graph generation
Understanding the structure of complex infrastructure
Validating that all resources are being correctly processed
Learning how Terramaid transforms Terraform graphs into Mermaid diagrams

## What

What Information Is Provided
In verbose mode, Terramaid will output additional information, including:

Configuration options being used
Terraform initialization progress
Graph parsing details
Node and edge processing information
Counts of resources detected
File operations

## References
`closes #96 `


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `--verbose` (`-v`) command-line flag and `TERRAMAID_VERBOSE` environment variable to enable detailed verbose output for all commands.

- **Refactor**
	- Enhanced logging to provide step-by-step information during Terraform processing and diagram generation when verbose mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->