### PR TITLE
build(gha): make gha tests use -v flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -w test/aws
+          build/terramaid run -wv test/aws
           cat Terramaid.md
   test_gcp:
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -w test/gcp
+          build/terramaid run -wv test/gcp
           cat Terramaid.md
   test_az:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -w test/az
+          build/terramaid run -wv test/az
           cat Terramaid.md
   test_multi:
     runs-on: ubuntu-latest
@@ -57,5 +57,5 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -w test/multi
+          build/terramaid run -wv test/multi
           cat Terramaid.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -wv test/aws
+          build/terramaid run -v -w test/aws
           cat Terramaid.md
   test_gcp:
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -wv test/gcp
+          build/terramaid run -v -w test/gcp
           cat Terramaid.md
   test_az:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -wv test/az
+          build/terramaid run -v -w test/az
           cat Terramaid.md
   test_multi:
     runs-on: ubuntu-latest
@@ -57,5 +57,5 @@ jobs:
           cache: false
       - run: |
           make build
-          build/terramaid run -wv test/multi
+          build/terramaid run -v -w test/multi
           cat Terramaid.md


### PR DESCRIPTION
## Why
Adds testing for the -v,  --verbose flag implemented in #97 

## What
Makes sure that any future changes doesn't break the verbose output functionality

## References
blocked by #97 