### PR TITLE
DEV-19 Incorporate `context.Context` for Commands

### DIFF
--- a/internal/flowchart.go
+++ b/internal/flowchart.go
@@ -4,6 +4,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -40,7 +41,7 @@ func CleanLabel(label string) string {
 }
 
 // GenerateMermaidFlowchart generates a Mermaid diagram from a gographviz graph
-func GenerateMermaidFlowchart(graph *gographviz.Graph, direction string, subgraphName string, verbose bool) (string, error) {
+func GenerateMermaidFlowchart(ctx context.Context, graph *gographviz.Graph, direction string, subgraphName string, verbose bool) (string, error) {
 	validDirections := map[string]bool{"TB": true, "TD": true, "BT": true, "RL": true, "LR": true}
 	if !validDirections[direction] {
 		return "", fmt.Errorf("invalid direction %s: valid options are TB, TD, BT, RL, LR", direction)
@@ -135,12 +136,12 @@ func GenerateMermaidFlowchart(graph *gographviz.Graph, direction string, subgrap
 	}
 
 	sb.WriteString("```\n")
-	
+
 	if verbose {
 		nodeCount := len(addedNodes)
 		edgeCount := len(graph.Edges.Edges)
 		utils.LogVerbose("Mermaid diagram generation complete with %d nodes and %d edges", nodeCount, edgeCount)
 	}
-	
+
 	return sb.String(), nil
 }

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -21,14 +21,12 @@ const emptyGraph = `digraph G {
 `
 
 // ParseTerraform parses the Terraform plan and returns the generated graph
-func ParseTerraform(workingDir, tfPath, planFile string, verbose bool) (*gographviz.Graph, error) {
-	ctx := context.Background()
-	
+func ParseTerraform(ctx context.Context, workingDir, tfPath, planFile string, verbose bool) (*gographviz.Graph, error) {
 	if verbose {
 		utils.LogVerbose("Initializing Terraform with working directory: %s", workingDir)
 		utils.LogVerbose("Using Terraform binary: %s", tfPath)
 	}
-	
+
 	tf, err := tfexec.NewTerraform(workingDir, tfPath)
 	if err != nil {
 		return nil, err
@@ -37,7 +35,7 @@ func ParseTerraform(workingDir, tfPath, planFile string, verbose bool) (*gograph
 	if verbose {
 		utils.LogVerbose("Running terraform init with upgrade=true")
 	}
-	
+
 	if err := tf.Init(ctx, tfexec.Upgrade(true)); err != nil {
 		return nil, err
 	}
@@ -56,7 +54,7 @@ func ParseTerraform(workingDir, tfPath, planFile string, verbose bool) (*gograph
 	if verbose {
 		utils.LogVerbose("Running terraform graph command")
 	}
-	
+
 	output, err := tf.Graph(ctx, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Why

- This PR integrating context.Context support throughout the diagram generation flow, enabling clean timeout handling and graceful cancellation. It introduces a `--timeout` flag and corresponding `TERRAMAID_TIMEOUT` environment variable, allowing users to limit execution time

Closes #99 