### PR TITLE
fix: handle non-200 responses in version fetch

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -48,6 +48,10 @@ func latestRelease() (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch version: HTTP %d", resp.StatusCode)
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)


### PR DESCRIPTION
## What

This pull request improves error handling in the `latestRelease` function in `cmd/version.go` by checking the HTTP response status code and returning a descriptive error if the request was not successful.

- Error handling improvements:
  * Added a check for `resp.StatusCode` to ensure it is `http.StatusOK` and return a clear error message if not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when checking for version updates with clearer error messages when version information cannot be retrieved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->