### PR TITLE
Fix flake resolution issues due to unpinned go version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,17 +59,17 @@
     },
     "nixpkgs-go": {
       "locked": {
-        "lastModified": 1774181343,
-        "narHash": "sha256-sNlLKEz1jXpMZngw6ovaPUk6s0dGij0xYtlArw48EUA=",
+        "lastModified": 1772801855,
+        "narHash": "sha256-lyMJ2u3rgG1+PYX0mNlwtk1EopVUsypnPY4SMi22aQQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fcd023ec9e17481b4f80ffec0e9d0f36ed847b91",
+        "rev": "ef9ca28baceba7da849e0fdb18bab8d3173fd208",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fcd023ec9e17481b4f80ffec0e9d0f36ed847b91",
+        "rev": "ef9ca28baceba7da849e0fdb18bab8d3173fd208",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-go": {
+      "locked": {
+        "lastModified": 1774181343,
+        "narHash": "sha256-sNlLKEz1jXpMZngw6ovaPUk6s0dGij0xYtlArw48EUA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fcd023ec9e17481b4f80ffec0e9d0f36ed847b91",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fcd023ec9e17481b4f80ffec0e9d0f36ed847b91",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-go": "nixpkgs-go"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A utility for generating Mermaid diagrams from Terraform configurations";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-go.url = "github:nixos/nixpkgs/fcd023ec9e17481b4f80ffec0e9d0f36ed847b91";
+    nixpkgs-go.url = "github:nixos/nixpkgs/ef9ca28baceba7da849e0fdb18bab8d3173fd208";
     flake-utils.url = "github:numtide/flake-utils";
 
     gomod2nix = {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,11 @@
     // {
       overlays.default = final: prev: {
         terramaid = import ./default.nix {
-          pkgs = final.extend gomod2nix.overlays.default;
+          pkgs =
+            (final.extend gomod2nix.overlays.default).extend
+            (final: prev: {
+              go = nixpkgs-go.packages.${final.stdenv.hostPlatform.system}.go;
+            });
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "A utility for generating Mermaid diagrams from Terraform configurations";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-go.url = "github:nixos/nixpkgs/fcd023ec9e17481b4f80ffec0e9d0f36ed847b91";
     flake-utils.url = "github:numtide/flake-utils";
 
     gomod2nix = {
@@ -15,13 +16,19 @@
   outputs = {
     self,
     nixpkgs,
+    nixpkgs-go,
     flake-utils,
     gomod2nix,
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [gomod2nix.overlays.default];
+        overlays = [
+          gomod2nix.overlays.default
+          (final: prev: {
+            go = nixpkgs-go.packages.${system}.go;
+          })
+        ];
       };
       callPackage = pkgs.callPackage;
     in {


### PR DESCRIPTION
## Why

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Nix flakes should now successfully build even when the Go version changes in nixpkgs-unstable

## What

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Pinned the go version to a specific revision of nixpkgs
- Applied an overlay that solely modifies the go package

## References

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- [Git bisect tutorial (very handy reference for this change)](https://stackoverflow.com/questions/4713088/how-do-i-use-git-bisect)

### Evidence

Recently, attempting to build the flake resulted in issues like this:
```
error:
       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while evaluating strict
         at «internal»:1:552:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: go.mod specified Go version 1.25.8, but no compatible Go attribute could be found.

       note: trace involved the following derivations:
       derivation 'terramaid-2.6.2'
```

### Git Bisect Result
<img width="654" height="198" alt="Screenshot 2026-04-30 at 14 09 09" src="https://github.com/user-attachments/assets/4d588af6-674f-428c-a4eb-93682751396f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to source an alternate Go toolchain for builds.
  * Ensures the Go toolchain is selected per target system, improving consistency of Go-based builds across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->