### PR TITLE
chore(homebrew): use updated homebrew bump action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,10 +121,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+      - uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
-          formula-name: terramaid
-          formula-path: Formula/t/terramaid.rb
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          formula: terramaid

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,3 +125,4 @@ jobs:
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
           formula: terramaid
+          token: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## what and why

Replace mislav/bump-homebrew-formula-action with dawidd6/action-homebrew-bump-formula (pinned to a specific commit / v7). Update the workflow input from formula-name/formula-path to the single `formula` key and remove the now-unnecessary COMMITTER_TOKEN env entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Homebrew package release workflow: replaced the previous formula-bump action with an alternate action and simplified the formula bump configuration for a more streamlined release step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->